### PR TITLE
fix: skip projects that 404/error out

### DIFF
--- a/project_tldr.py
+++ b/project_tldr.py
@@ -7,6 +7,8 @@ from os import environ
 from snyk import SnykClient
 from snykv3 import SnykV3Client
 
+import snyk
+
 snyk_token = environ["SNYK_TOKEN"]
 
 SCM_REPOS = (
@@ -67,8 +69,11 @@ def build_csv(org_id, int_name, csv_file, tags, snyk_token):
         for project in get_all_projects(org_id, clientv3, tags, target):
             proj_attr = project["attributes"]
             proj_attr["repoName"] = target["attributes"]["displayName"]
-            v1_data = get_project_data(org_id, project["id"], clientv1)
-            the_data.append(proj_attr | v1_data)
+            try:
+              v1_data = get_project_data(org_id, project["id"], clientv1)
+              the_data.append(proj_attr | v1_data)
+            except snyk.errors.SnykHTTPError as error:
+              print(f"Error retrieving project, skipping...")
 
     headers = [i for i in the_data[0].keys()]
 


### PR DESCRIPTION
for some strange reason to investigate later, in rare cases with some orgs I'm running this against, some projects 404 when trying to retrieve them, even though they are listed in the org's project list. When trying to access the projects directly in the UI by URL, it says that there are no snapshots for the project.  In order to skip and move to the next project, this change just catches the exceptions to avoid the script from exiting.